### PR TITLE
fix: handle iframe focus-stealing in preview/code toggle

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -67,8 +67,8 @@ export function MainContent({ user, project }: MainContentProps) {
                     }
                   >
                     <TabsList className="bg-white/60 border border-neutral-200/60 p-0.5 h-9 shadow-sm">
-                      <TabsTrigger value="preview" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Preview</TabsTrigger>
-                      <TabsTrigger value="code" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Code</TabsTrigger>
+                      <TabsTrigger value="preview" onPointerDown={() => setActiveView("preview")} className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Preview</TabsTrigger>
+                      <TabsTrigger value="code" onPointerDown={() => setActiveView("code")} className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Code</TabsTrigger>
                     </TabsList>
                   </Tabs>
                   <HeaderActions user={user} projectId={project?.id} />


### PR DESCRIPTION
Fixes #Issue: toggle button

The toggle between Preview and Code tabs sometimes didn't respond after the user had clicked inside the preview iframe. Root cause is the classic iframe focus-stealing bug: the iframe captures browser focus, and Radix UI's TabsTrigger relies on the `click` event to update state, which can be swallowed during the iframe blur sequence in some browsers.

Adds `onPointerDown` handlers to both tab triggers so the state updates on pointer-down — before any focus changes happen.

Generated with [Claude Code](https://claude.ai/code)